### PR TITLE
TECH-30764 Remove Creds from Nuget.Config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,9 @@ jobs:
     - name: Test Samples
       run: dotnet test --no-restore --verbosity normal ./samples/MyCRM.Lodgement.Sample.Tests/MyCRM.Lodgement.Sample.Tests.csproj
     - name: Build Docker image
-      run: docker build . -f ./samples/MyCRM.Lodgement.Sample/Dockerfile -t lodgementsample:latest
+      run: |
+        echo ${{secrets.LOAN_MARKET_TOKEN_READ_ONLY }}> ./nugetLoginToken.secret
+        docker build . -f ./samples/MyCRM.Lodgement.Sample/Dockerfile -t lodgementsample:latest --secret id=NUGET_LOGIN_TOKEN,src=./nugetLoginToken.secret
     - name: Save Docker image to file
       run: docker save lodgementsample:latest -o lodgementsample-docker-image.tar
     - name: Save Docker image as an artifact
@@ -28,3 +30,4 @@ jobs:
       with:
         name: lodgementsample-docker-image
         path: lodgementsample-docker-image.tar
+        

--- a/samples/MyCRM.Lodgement.Sample/Dockerfile
+++ b/samples/MyCRM.Lodgement.Sample/Dockerfile
@@ -20,6 +20,8 @@ RUN dotnet publish \
     --configuration Release \
     --output "/app/publish"
 
+
+
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim AS final
 WORKDIR /app
 COPY --from=build /app/publish .

--- a/samples/NuGet.Config
+++ b/samples/NuGet.Config
@@ -5,12 +5,7 @@
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
         <add key="lmgithubnuget" value="https://nuget.pkg.github.com/loanmarket/index.json" />
     </packageSources>
-    <packageSourceCredentials>
-        <lmgithubnuget>
-            <add key="Username" value="license.admin@loanmarket.com.au" />
-            <add key="ClearTextPassword" value="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" />
-        </lmgithubnuget>
-    </packageSourceCredentials>
+
     <packageSourceMapping>
         <packageSource key="nuget.org">
             <package pattern="*" />


### PR DESCRIPTION
### Linked ClickUp: TECH-30764

### The challenge being addressed:
The solution has a dependency on LMGTech.DotNetLixi nuget source which private and the nuget source should get added for building the docker image. To do so, a username and token should be provided and to have a safe solution the secret should get obtained from github secrets instead of reading credentials from nuget.config file.