### PR TITLE
feat: bump swagger to 6.7.3 and remove Hellang.Middleware

### DIFF
--- a/samples/MyCRM.Lodgement.Sample/MyCRM.Lodgement.Sample.csproj
+++ b/samples/MyCRM.Lodgement.Sample/MyCRM.Lodgement.Sample.csproj
@@ -12,11 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="5.1.1" />
     <PackageReference Include="LMGTech.DotNetLixi" Version="0.0.85" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.0.7" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.0.7" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.0.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.7.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.7.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.7.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION

Bumping Swagger to newest version to address [CVE-2018-25031](https://www.cve.org/CVERecord?id=CVE-2018-25031). I've bumped to the most recent version, minimum version which fixes the CVE is 6.3.0.

Removing `Hellang.Middleware.ProblemDetails` as it doesn't appear to be in use.

I haven't been able to test these changes. 
