### PR TITLE
TECH-30764 Update dockerfile to run image with non-root user

### DIFF
--- a/samples/MyCRM.Lodgement.Sample/Dockerfile
+++ b/samples/MyCRM.Lodgement.Sample/Dockerfile
@@ -23,9 +23,17 @@ RUN dotnet publish \
 
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim AS final
+
+RUN groupadd -r appgroup && useradd -r -g appgroup appuser
+
 WORKDIR /app
 COPY --from=build /app/publish .
 
 LABEL org.opencontainers.image.source=https://github.com/loanmarket/mycrm-lodgement-sample
+
+# Create a user
+RUN chown -R appuser:appgroup /app
+# Switch to the non-root user
+USER appuser
 
 ENTRYPOINT ["dotnet", "MyCRM.Lodgement.Sample.dll"]


### PR DESCRIPTION
### Linked ClickUp: TECH-30764
### The challenge being addressed:
The docker image should run with a non-root user due to security matters discusses [here](https://www.docker.com/blog/understanding-the-docker-user-instruction/). These changes in Dockerfile is to achieve so.