### PR TITLE
Bump test project packages to avoid vulnerabilities

### DIFF
--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -14,11 +14,17 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.3" />
     <PackageVersion Include="FluentAssertions" Version="8.5.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.18" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageVersion Include="Moq" Version="4.16.1" />
-    <PackageVersion Include="xunit" Version="2.4.1" />
-    <PackageVersion Include="xunit.runner.utility" Version="2.4.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageVersion Include="coverlet.collector" Version="1.2.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.utility" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
+    <PackageVersion Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Static code analysis identified vulnerabilities in the test project. Updated dependencies to prevent vulnerabilities.

Before:
<img width="1317" height="567" alt="image" src="https://github.com/user-attachments/assets/685f17cf-8da1-49da-b03c-9ea1e264e79f" />
<img width="1308" height="557" alt="image" src="https://github.com/user-attachments/assets/db9ecb02-78b0-491f-8b9c-6a3a6b4d9842" />

Results of `snyk test` after update:
<img width="385" height="53" alt="image" src="https://github.com/user-attachments/assets/48797401-bc97-404f-9a66-f061100fcf2b" />
